### PR TITLE
Bump `optimum` to 1.16.2 to resolve import error

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To utilize the QEB8L model for Biomedical Named Entity Recognition, follow the s
 
 
 ```
-pip install optimum==1.8.8
+pip install optimum==1.16.2
 pip install onnx==1.13.1
 pip install onnxruntime==1.15.1
 ```
@@ -112,7 +112,7 @@ The entity types are as follows: 'GP': Gene/Protein, 'CD': Chemical/Drug, 'OG': 
 [814, 825, 'lung cancer', 'DS', 0.9988202]
 [895, 899, 'ACE2', 'GP', 0.9993438]
 [914, 924, 'lung tumor', 'DS', 0.9986173]
-[991, 1011, 'SARS-CoV-2 infection', 'DS'0.9965901]
+[991, 1011, 'SARS-CoV-2 infection', 'DS', 0.9965901]
 [1046, 1050, 'LUAD', 'DS', 0.9971084]
 [1055, 1059, 'LUSC', 'DS', 0.99671656]
 [1070, 1092, 'Chronic kidney disease', 'DS', 0.998764]


### PR DESCRIPTION
As I was experimenting with the repository, I noticed that installing a blank virtual environment and following the instructions in README leads to:

```
RuntimeError: Failed to import optimum.onnxruntime.modeling_ort because of the following error (look up to see its traceback):
Failed to import optimum.exporters.onnx.__main__ because of the following error (look up to see its traceback):
cannot import name 'is_torch_less_than_1_11' from 'transformers.pytorch_utils' (/home/ktsukanov/repositories/literature/annotation_models/myenv/lib/python3.10/site-packages/transformers/pytorch_utils.py)
```

This is because part of the code was recently removed in https://github.com/huggingface/transformers/pull/28207. This has then been addressed in https://github.com/huggingface/optimum/pull/1641, so upgrading to `optimum==1.16.2` solves the problem.